### PR TITLE
Fix "substate" case sensitivity bug

### DIFF
--- a/source/gameFolder/meta/state/charting/ChartingState.hx
+++ b/source/gameFolder/meta/state/charting/ChartingState.hx
@@ -21,7 +21,7 @@ import gameFolder.meta.MusicBeat.MusicBeatState;
 import gameFolder.meta.data.*;
 import gameFolder.meta.data.Section.SwagSection;
 import gameFolder.meta.data.Song.SwagSong;
-import gameFolder.meta.substate.charting.*;
+import gameFolder.meta.subState.charting.*;
 import haxe.io.Bytes;
 import lime.media.AudioBuffer;
 import openfl.geom.Rectangle;

--- a/source/gameFolder/meta/subState/charting/PreferenceSubstate.hx
+++ b/source/gameFolder/meta/subState/charting/PreferenceSubstate.hx
@@ -1,4 +1,4 @@
-package gameFolder.meta.substate.charting;
+package gameFolder.meta.subState.charting;
 
 import flixel.FlxCamera;
 import flixel.FlxG;


### PR DESCRIPTION
Building on Linux fails and gives me the following error:

    source/gameFolder/meta/state/charting/ChartingState.hx:237: characters 21-39 : Type not found : PreferenceSubstate

I managed to track it down to a simple case sensitive filesystem bug - in the path `gameFolder/meta/substate/charting`, the folder `substate` is actually named `subState`.
All other instances of `import gameFolder.meta.subState` are properly capitalized.